### PR TITLE
If the groups mutable array is emptied at some point before cellForRowAt...

### DIFF
--- a/UzysAssetsPickerController/Library/UzysGroupPickerView.m
+++ b/UzysAssetsPickerController/Library/UzysGroupPickerView.m
@@ -117,7 +117,11 @@
     {
         cell = [[UzysGroupViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
     }
-    [cell applyData:[self.groups objectAtIndex:indexPath.row]];
+    
+    if (self.groups.count > 0) {
+        [cell applyData:[self.groups objectAtIndex:indexPath.row]];
+    }
+    
     return cell;
 }
 


### PR DESCRIPTION
...IndexPath is called, this can cause a crash.

Intermittently I've come across a crash when taking photos with the camera using this library, and Crashlytics reports this as being an `NSRange Exception: Index 0 beyond bounds for empty array` as seen below. I've found this a tough nut to crack in terms of reproducibility, but I can say that it only seems to happen when taking a photo. Also, this was mentioned in a side-comment on https://github.com/uzysjung/UzysAssetsPickerController/issues/20.

![screenshot 2015-01-06 11 55 04](https://cloud.githubusercontent.com/assets/6086409/5632205/ec84616c-959a-11e4-9716-c810d0e8b5bc.png)

This was quite puzzling to me as normally `cellForRowAtIndexPath:` isn't called when the data source array is empty, so I figured there was some issue where perhaps the `groups` property on the `UzysGroupPickerView` was altered without updating the tableview.

In going through the code briefly in an attempt to track down the issue, my understanding is that the `UzysAssetsPickerController` has a `UzysGroupPickerView` property that it initializes with the `groups` mutable array property in the picker controller's view did load process, and there are a few places in which the picker controller updates the `groups` property on itself without updating the groups property on the `groupPicker`. 

My observations seemed to be the opposite of what I was expecting when I hypothesized the issue, so I figured because you have a better understanding of how this all works perhaps you might know what the issue may be.

Either way this seemingly superfluous check to ensure that the groups count is greater than 0 before attempting to obtain an `objectAtIndex:` in the `groups` property of the picker view should at least prevent this crash in the short-term until the deeper cause is determined. Let me know what you think.