### PR TITLE
Lowercase delegate methods so bridged symbols don't conflict in Swift

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
@@ -12,10 +12,10 @@
 
 @class UzysAssetsPickerController;
 @protocol UzysAssetsPickerControllerDelegate<NSObject>
-- (void)UzysAssetsPickerController:(UzysAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets;
+- (void)uzysAssetsPickerController:(UzysAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets;
 @optional
-- (void)UzysAssetsPickerControllerDidCancel:(UzysAssetsPickerController *)picker;
-- (void)UzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:(UzysAssetsPickerController *)picker;
+- (void)uzysAssetsPickerControllerDidCancel:(UzysAssetsPickerController *)picker;
+- (void)uzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:(UzysAssetsPickerController *)picker;
 @end
 
 @interface UzysAssetsPickerController : UIViewController

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -583,7 +583,7 @@
 - (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     BOOL didExceedMaximumNumberOfSelection = [collectionView indexPathsForSelectedItems].count >= self.maximumNumberOfSelection;
-    if (didExceedMaximumNumberOfSelection && self.delegate && [self.delegate respondsToSelector:@selector(UzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:)]) {
+    if (didExceedMaximumNumberOfSelection && self.delegate && [self.delegate respondsToSelector:@selector(uzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:)]) {
         [self.delegate uzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:self];
     }
     return !didExceedMaximumNumberOfSelection;
@@ -615,7 +615,7 @@
     {
         UzysAssetsPickerController *picker = (UzysAssetsPickerController *)self;
         
-        if([picker.delegate respondsToSelector:@selector(UzysAssetsPickerController:didFinishPickingAssets:)])
+        if([picker.delegate respondsToSelector:@selector(uzysAssetsPickerController:didFinishPickingAssets:)])
             [picker.delegate uzysAssetsPickerController:picker didFinishPickingAssets:assets];
         
         [self dismissViewControllerAnimated:YES completion:^{
@@ -837,7 +837,7 @@
             break;
         case kTagButtonClose:
         {
-            if([self.delegate respondsToSelector:@selector(UzysAssetsPickerControllerDidCancel:)])
+            if([self.delegate respondsToSelector:@selector(uzysAssetsPickerControllerDidCancel:)])
             {
                 [self.delegate uzysAssetsPickerControllerDidCancel:self];
             }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -584,7 +584,7 @@
 {
     BOOL didExceedMaximumNumberOfSelection = [collectionView indexPathsForSelectedItems].count >= self.maximumNumberOfSelection;
     if (didExceedMaximumNumberOfSelection && self.delegate && [self.delegate respondsToSelector:@selector(UzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:)]) {
-        [self.delegate UzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:self];
+        [self.delegate uzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:self];
     }
     return !didExceedMaximumNumberOfSelection;
 }
@@ -616,7 +616,7 @@
         UzysAssetsPickerController *picker = (UzysAssetsPickerController *)self;
         
         if([picker.delegate respondsToSelector:@selector(UzysAssetsPickerController:didFinishPickingAssets:)])
-            [picker.delegate UzysAssetsPickerController:picker didFinishPickingAssets:assets];
+            [picker.delegate uzysAssetsPickerController:picker didFinishPickingAssets:assets];
         
         [self dismissViewControllerAnimated:YES completion:^{
             
@@ -839,7 +839,7 @@
         {
             if([self.delegate respondsToSelector:@selector(UzysAssetsPickerControllerDidCancel:)])
             {
-                [self.delegate UzysAssetsPickerControllerDidCancel:self];
+                [self.delegate uzysAssetsPickerControllerDidCancel:self];
             }
             [self dismissViewControllerAnimated:YES completion:^{
                 

--- a/UzysAssetsPickerController/uzysViewController.m
+++ b/UzysAssetsPickerController/uzysViewController.m
@@ -116,7 +116,7 @@
 }
 
 #pragma mark - UzysAssetsPickerControllerDelegate methods
-- (void)UzysAssetsPickerController:(UzysAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets
+- (void)uzysAssetsPickerController:(UzysAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets
 {
     self.imageView.backgroundColor = [UIColor clearColor];
     DLog(@"assets %@",assets);
@@ -177,7 +177,7 @@
     
 }
 
-- (void)UzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:(UzysAssetsPickerController *)picker
+- (void)uzysAssetsPickerControllerDidExceedMaximumNumberOfSelection:(UzysAssetsPickerController *)picker
 {
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@""
                                                     message:NSLocalizedStringFromTable(@"Exceed Maximum Number Of Selection", @"UzysAssetsPickerController", nil)


### PR DESCRIPTION
I tried to use this lib in swift and these methods caused a naming conflict with the class name when imported via a bridged header. Lowercasing the first letter in delegate method names is more conventional and fixes the bug