### PR TITLE
Feature: hide the navigation bar and use asset picker within another view controller

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) NSString *cameraImageName;
 @property (nonatomic, strong) NSString *closeImageName;
 @property (nonatomic, strong) UIColor *finishSelectionButtonColor;
+@property (nonatomic) BOOL useInline;
 
 + (instancetype)sharedConfig;
 @end

--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong) NSString *assetsGroupSelectedImageName;
 @property (nonatomic, strong) NSString *cameraImageName;
 @property (nonatomic, strong) NSString *closeImageName;
+@property (nonatomic, strong) UIColor *initialSelectionButtonColor;
 @property (nonatomic, strong) UIColor *finishSelectionButtonColor;
 @property (nonatomic) BOOL useInline;
 

--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
@@ -60,6 +60,14 @@
     return _closeImageName;
 }
 
+- (UIColor *)initialSelectionButtonColor
+{
+    if (!_initialSelectionButtonColor) {
+        return [UIColor lightGrayColor];
+    }
+    return _initialSelectionButtonColor;
+}
+
 - (UIColor *)finishSelectionButtonColor
 {
     if (!_finishSelectionButtonColor) {
@@ -67,5 +75,7 @@
     }
     return _finishSelectionButtonColor;
 }
+
+
 
 @end

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
@@ -9,6 +9,8 @@
 #import <UIKit/UIKit.h>
 #import "UzysAssetsPickerController_Configuration.h"
 #import "UzysAppearanceConfig.h"
+#import "UzysWrapperPickerController.h"
+#import "UzysGroupPickerView.h"
 
 @class UzysAssetsPickerController;
 @protocol UzysAssetsPickerControllerDelegate<NSObject>
@@ -24,6 +26,10 @@
 @property (nonatomic, assign) NSInteger maximumNumberOfSelectionPhoto;
 //--------------------------------------------------------------------
 @property (nonatomic, assign) NSInteger maximumNumberOfSelectionMedia;
+
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) UzysWrapperPickerController *picker;
+@property (nonatomic, strong) UzysGroupPickerView *groupPicker;
 
 @property (nonatomic, weak) id <UzysAssetsPickerControllerDelegate> delegate;
 + (ALAssetsLibrary *)defaultAssetsLibrary;

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -444,9 +444,9 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40 - 64);
-        message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20 - 64);
-        titleImage.center       = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - titleImage.frame.size.height /2 -64);
+        title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40 - 90);
+        message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20 - 90);
+        titleImage.center       = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - titleImage.frame.size.height /2 - 90);
     } else {
         title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40);
         message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20);
@@ -638,10 +638,14 @@
         
         if([picker.delegate respondsToSelector:@selector(uzysAssetsPickerController:didFinishPickingAssets:)])
             [picker.delegate uzysAssetsPickerController:picker didFinishPickingAssets:assets];
-        
-        [self dismissViewControllerAnimated:YES completion:^{
-            
-        }];
+
+        // Don't dismiss view controller when shown inline.
+        UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+        if (!appearanceConfig.useInline) {
+            [self dismissViewControllerAnimated:YES completion:^{
+
+            }];
+        }
     }
 }
 #pragma mark - Helper methods

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -227,7 +227,7 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(8, 0, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
     } else {
         self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
     }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -154,7 +154,12 @@
     };
     
     [self.view insertSubview:self.groupPicker aboveSubview:self.bottomView];
-    [self.view bringSubviewToFront:self.navigationTop];
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    if (appearanceConfig.useInline) {
+        [self.navigationTop setHidden:YES];
+    } else {
+        [self.view bringSubviewToFront:self.navigationTop];
+    }
     [self menuArrowRotate];
 
 }
@@ -219,7 +224,13 @@
     layout.minimumInteritemSpacing      = 1.0;
     layout.minimumLineSpacing           = 1.0;
 
-    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 -48) collectionViewLayout:layout];
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    if (appearanceConfig.useInline) {
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+    } else {
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
+    }
+
     self.collectionView.allowsMultipleSelection = YES;
     [self.collectionView registerClass:[UzysAssetsViewCell class]
             forCellWithReuseIdentifier:kAssetsViewCellIdentifier];
@@ -248,6 +259,7 @@
     appearanceConfig.finishSelectionButtonColor = config.finishSelectionButtonColor;
     appearanceConfig.assetsGroupSelectedImageName = config.assetsGroupSelectedImageName;
     appearanceConfig.closeImageName = config.closeImageName;
+    appearanceConfig.useInline = config.useInline;
 }
 
 - (void)changeGroup:(NSInteger)item

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -227,7 +227,7 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
     } else {
         self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
     }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -227,7 +227,7 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 8, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(8, 0, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
     } else {
         self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
     }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -441,10 +441,18 @@
     
     [title sizeToFit];
     [message sizeToFit];
-    
-    title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40);
-    message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20);
-    titleImage.center       = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - titleImage.frame.size.height /2);
+
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    if (appearanceConfig.useInline) {
+        title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40 - 64);
+        message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20 - 64);
+        titleImage.center       = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - titleImage.frame.size.height /2 -64);
+    } else {
+        title.center            = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - title.frame.size.height / 2 + 40);
+        message.center          = CGPointMake(noAssetsView.center.x, noAssetsView.center.y + 10 + message.frame.size.height / 2 + 20);
+        titleImage.center       = CGPointMake(noAssetsView.center.x, noAssetsView.center.y - 10 - titleImage.frame.size.height /2);
+    }
+
     [noAssetsView addSubview:title];
     [noAssetsView addSubview:message];
     [noAssetsView addSubview:titleImage];

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -226,7 +226,7 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 8, [UIScreen mainScreen].bounds.size.width - 16, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
     } else {
         self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
     }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -226,7 +226,7 @@
 
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     if (appearanceConfig.useInline) {
-        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
     } else {
         self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
     }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -7,8 +7,6 @@
 //
 #import "UzysAssetsPickerController.h"
 #import "UzysAssetsViewCell.h"
-#import "UzysWrapperPickerController.h"
-#import "UzysGroupPickerView.h"
 @interface UzysAssetsPickerController ()<UICollectionViewDataSource,UICollectionViewDelegate,UIImagePickerControllerDelegate,UINavigationControllerDelegate>
 //View
 @property (weak, nonatomic) IBOutlet UIImageView *imageViewTitleArrow;
@@ -22,9 +20,12 @@
 @property (weak, nonatomic) IBOutlet UIButton *btnClose;
 
 @property (nonatomic, strong) UIView *noAssetView;
-@property (nonatomic, strong) UICollectionView *collectionView;
-@property (nonatomic, strong) UzysWrapperPickerController *picker;
-@property (nonatomic, strong) UzysGroupPickerView *groupPicker;
+
+// Making these public so I have access to config from parent view controller
+// @property (nonatomic, strong) UICollectionView *collectionView;
+// @property (nonatomic, strong) UzysWrapperPickerController *picker;
+// @property (nonatomic, strong) UzysGroupPickerView *groupPicker;
+
 //@property (nonatomic, strong) UzysGroupPickerViewController *groupPicker;
 
 @property (nonatomic, strong) ALAssetsGroup *assetsGroup;
@@ -237,7 +238,7 @@
     
     self.collectionView.delegate = self;
     self.collectionView.dataSource = self;
-    self.collectionView.backgroundColor = [UIColor whiteColor];
+    self.collectionView.backgroundColor = [UIColor clearColor];
     self.collectionView.bounces = YES;
     self.collectionView.alwaysBounceVertical = YES;
 

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
@@ -120,7 +120,7 @@
                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" tag="102" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8h0-kN-iqH" userLabel="Button - Camera">
+                        <button hidden="YES" opaque="NO" tag="102" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8h0-kN-iqH" userLabel="Button - Camera">
                             <rect key="frame" x="8" y="9" width="30" height="30"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="30" id="DOI-aS-uvz"/>

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
@@ -76,17 +76,18 @@
                 <view tag="201" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kxD-PY-Oat" userLabel="BottomView">
                     <rect key="frame" x="0.0" y="520" width="320" height="48"/>
                     <subviews>
-                        <button opaque="NO" tag="104" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abt-dZ-axW">
-                            <rect key="frame" x="249" y="9" width="55" height="30"/>
+                        <button opaque="NO" tag="104" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abt-dZ-axW">
+                            <rect key="frame" x="274" y="9" width="30" height="30"/>
                             <color key="backgroundColor" red="0.88235294117647056" green="0.24313725490196078" blue="0.24313725490196078" alpha="1" colorSpace="calibratedRGB"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="55" id="QKW-c3-OwO"/>
+                                <constraint firstAttribute="width" constant="30" id="QKW-c3-OwO"/>
                             </constraints>
                             <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="15"/>
                             <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <inset key="contentEdgeInsets" minX="-24" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <inset key="titleEdgeInsets" minX="-32" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <inset key="imageEdgeInsets" minX="32" minY="1" maxX="0.0" maxY="0.0"/>
-                            <state key="normal" title="0" image="UzysAssetPickerController.bundle/uzysAP_ico_upload_done.png">
+                            <state key="normal" image="UzysAssetPickerController.bundle/uzysAP_ico_upload_done.png">
                                 <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
                             <connections>

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.xib
@@ -114,7 +114,7 @@
                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Photo" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HUE-lo-MS3">
                             <rect key="frame" x="110" y="12" width="100" height="24"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="100" id="HP4-c4-4oE"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="HP4-c4-4oE"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>

--- a/UzysAssetsPickerController/uzysViewController.m
+++ b/UzysAssetsPickerController/uzysViewController.m
@@ -81,12 +81,13 @@
 - (void)btnAction:(id)sender
 {
     //if you want to checkout how to config appearance, just uncomment the following 4 lines code.
-#if 0
+//#if 0
     UzysAppearanceConfig *appearanceConfig = [[UzysAppearanceConfig alloc] init];
     appearanceConfig.finishSelectionButtonColor = [UIColor blueColor];
     appearanceConfig.assetsGroupSelectedImageName = @"checker.png";
+    appearanceConfig.useInline = YES;
     [UzysAssetsPickerController setUpAppearanceConfig:appearanceConfig];
-#endif
+//#endif
 
     UzysAssetsPickerController *picker = [[UzysAssetsPickerController alloc] init];
     picker.delegate = self;


### PR DESCRIPTION
Adds the ability to set a `useInline` flag to the appearance configuration. This hides the navigation bar and lets the asset picker sit inline. I found it useful for making the asset picker behave as a child view controller within a view that already had it's own navigation bar.