### PR TITLE
Feature: hide the navigation bar and use asset picker within another view controller

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) NSString *cameraImageName;
 @property (nonatomic, strong) NSString *closeImageName;
 @property (nonatomic, strong) UIColor *finishSelectionButtonColor;
+@property (nonatomic) BOOL useInline;
 
 + (instancetype)sharedConfig;
 @end

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -154,7 +154,12 @@
     };
     
     [self.view insertSubview:self.groupPicker aboveSubview:self.bottomView];
-    [self.view bringSubviewToFront:self.navigationTop];
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    if (appearanceConfig.useInline) {
+        [self.navigationTop setHidden:YES];
+    } else {
+        [self.view bringSubviewToFront:self.navigationTop];
+    }
     [self menuArrowRotate];
 
 }
@@ -219,7 +224,13 @@
     layout.minimumInteritemSpacing      = 1.0;
     layout.minimumLineSpacing           = 1.0;
 
-    self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 -48) collectionViewLayout:layout];
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    if (appearanceConfig.useInline) {
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 48) collectionViewLayout:layout];
+    } else {
+        self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 - 48) collectionViewLayout:layout];
+    }
+
     self.collectionView.allowsMultipleSelection = YES;
     [self.collectionView registerClass:[UzysAssetsViewCell class]
             forCellWithReuseIdentifier:kAssetsViewCellIdentifier];
@@ -248,6 +259,7 @@
     appearanceConfig.finishSelectionButtonColor = config.finishSelectionButtonColor;
     appearanceConfig.assetsGroupSelectedImageName = config.assetsGroupSelectedImageName;
     appearanceConfig.closeImageName = config.closeImageName;
+    appearanceConfig.useInline = config.useInline;
 }
 
 - (void)changeGroup:(NSInteger)item

--- a/UzysAssetsPickerController/uzysViewController.m
+++ b/UzysAssetsPickerController/uzysViewController.m
@@ -81,12 +81,13 @@
 - (void)btnAction:(id)sender
 {
     //if you want to checkout how to config appearance, just uncomment the following 4 lines code.
-#if 0
+//#if 0
     UzysAppearanceConfig *appearanceConfig = [[UzysAppearanceConfig alloc] init];
     appearanceConfig.finishSelectionButtonColor = [UIColor blueColor];
     appearanceConfig.assetsGroupSelectedImageName = @"checker.png";
+    appearanceConfig.useInline = YES;
     [UzysAssetsPickerController setUpAppearanceConfig:appearanceConfig];
-#endif
+//#endif
 
     UzysAssetsPickerController *picker = [[UzysAssetsPickerController alloc] init];
     picker.delegate = self;


### PR DESCRIPTION
Adds the ability to set a `useInline` flag to the appearance configuration. This hides the navigation bar and lets the asset picker sit inline. I found it useful for making the asset picker behave as a child view controller within a view that already had it's own navigation bar.