### PR TITLE
Provide for geotagging images with location metadata

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.h
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 #import "UzysAssetsPickerController_Configuration.h"
 #import "UzysAppearanceConfig.h"
+#import <CoreLocation/CoreLocation.h>
 
 @class UzysAssetsPickerController;
 @protocol UzysAssetsPickerControllerDelegate<NSObject>
@@ -20,6 +21,7 @@
 
 @interface UzysAssetsPickerController : UIViewController
 @property (nonatomic, strong) ALAssetsFilter *assetsFilter;
+@property (nonatomic, strong) CLLocation * location;
 @property (nonatomic, assign) NSInteger maximumNumberOfSelectionVideo;
 @property (nonatomic, assign) NSInteger maximumNumberOfSelectionPhoto;
 //--------------------------------------------------------------------

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -9,6 +9,7 @@
 #import "UzysAssetsViewCell.h"
 #import "UzysWrapperPickerController.h"
 #import "UzysGroupPickerView.h"
+#import <ImageIO/ImageIO.h>
 
 @interface UzysAssetsPickerController ()<UICollectionViewDataSource,UICollectionViewDelegate,UIImagePickerControllerDelegate,UINavigationControllerDelegate>
 //View
@@ -38,14 +39,14 @@
 @property (nonatomic, assign) NSInteger maximumNumberOfSelection;
 @property (nonatomic, assign) NSInteger curAssetFilterType;
 
-@property (nonatomic, strong) NSMutableArray *orderedSelectedItem;
-
 - (IBAction)btnAction:(id)sender;
 - (IBAction)indexDidChangeForSegmentedControl:(id)sender;
 
 @end
 
 @implementation UzysAssetsPickerController
+
+@synthesize location;
 
 #pragma mark - ALAssetsLibrary
 
@@ -89,7 +90,7 @@
     [self initVariable];
     [self initImagePicker];
     [self setupOneMediaTypeSelection];
-
+    
     __weak typeof(self) weakSelf = self;
     [self setupGroup:^{
         [weakSelf.groupPicker.tableView selectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0] animated:NO scrollPosition:UITableViewScrollPositionNone];
@@ -103,16 +104,15 @@
 
 - (void)initVariable
 {
-//    self.assetsFilter = [ALAssetsFilter allPhotos];
+    //    self.assetsFilter = [ALAssetsFilter allPhotos];
     [self setAssetsFilter:[ALAssetsFilter allPhotos] type:1];
     self.maximumNumberOfSelection = self.maximumNumberOfSelectionPhoto;
     self.view.clipsToBounds = YES;
-    self.orderedSelectedItem = [[NSMutableArray alloc] init];
 }
 - (void)initImagePicker
 {
     UzysWrapperPickerController *picker = [[UzysWrapperPickerController alloc] init];
-//    picker.modalPresentationStyle = UIModalPresentationCurrentContext;
+    //    picker.modalPresentationStyle = UIModalPresentationCurrentContext;
     picker.delegate = self;
     picker.allowsEditing = NO;
     picker.videoQuality = UIImagePickerControllerQualityTypeHigh;
@@ -122,7 +122,7 @@
         [UIImagePickerController availableMediaTypesForSourceType:
          UIImagePickerControllerSourceTypeCamera];
         NSMutableArray *mediaTypes = [NSMutableArray arrayWithArray:availableMediaTypes];
-
+        
         if (_maximumNumberOfSelectionMedia == 0)
         {
             if (_maximumNumberOfSelectionPhoto == 0)
@@ -130,7 +130,7 @@
             else if (_maximumNumberOfSelectionVideo == 0)
                 [mediaTypes removeObject:@"public.movie"];
         }
-
+        
         picker.sourceType = UIImagePickerControllerSourceTypeCamera;
         picker.mediaTypes = mediaTypes;
     }
@@ -160,13 +160,13 @@
     [self.view insertSubview:self.groupPicker aboveSubview:self.bottomView];
     [self.view bringSubviewToFront:self.navigationTop];
     [self menuArrowRotate];
-
+    
 }
 - (void)setupOneMediaTypeSelection
 {
     if(_maximumNumberOfSelectionMedia > 0)
     {
-//        self.assetsFilter = [ALAssetsFilter allAssets];
+        //        self.assetsFilter = [ALAssetsFilter allAssets];
         [self setAssetsFilter:[ALAssetsFilter allAssets] type:0];
         self.maximumNumberOfSelection = self.maximumNumberOfSelectionMedia;
         self.segmentedControl.hidden = YES;
@@ -175,13 +175,13 @@
             self.labelSelectedMedia.text = NSLocalizedStringFromTable(@"Choose media", @"UzysAssetsPickerController", nil);
         else
             self.labelSelectedMedia.text = NSLocalizedStringFromTable(@"Choose a media", @"UzysAssetsPickerController", nil);
-
+        
     }
     else
     {
         if(_maximumNumberOfSelectionPhoto == 0)
         {
-//            self.assetsFilter = [ALAssetsFilter allVideos];
+            //            self.assetsFilter = [ALAssetsFilter allVideos];
             [self setAssetsFilter:[ALAssetsFilter allVideos] type:2];
             
             self.maximumNumberOfSelection = self.maximumNumberOfSelectionVideo;
@@ -194,7 +194,7 @@
         }
         else if(_maximumNumberOfSelectionVideo == 0)
         {
-//            self.assetsFilter = [ALAssetsFilter allPhotos];
+            //            self.assetsFilter = [ALAssetsFilter allPhotos];
             [self setAssetsFilter:[ALAssetsFilter allPhotos] type:1];
             
             self.segmentedControl.selectedSegmentIndex = 0;
@@ -235,7 +235,7 @@
     layout.sectionInset                 = UIEdgeInsetsMake(1.0, 0, 0, 0);
     layout.minimumInteritemSpacing      = 1.0;
     layout.minimumLineSpacing           = 1.0;
-
+    
     self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 -48) collectionViewLayout:layout];
     self.collectionView.allowsMultipleSelection = YES;
     [self.collectionView registerClass:[UzysAssetsViewCell class]
@@ -246,7 +246,7 @@
     self.collectionView.backgroundColor = [UIColor whiteColor];
     self.collectionView.bounces = YES;
     self.collectionView.alwaysBounceVertical = YES;
-
+    
     [self.view insertSubview:self.collectionView atIndex:0];
 }
 #pragma mark - Property
@@ -280,7 +280,7 @@
     if(isPhoto)
     {
         self.maximumNumberOfSelection = self.maximumNumberOfSelectionPhoto;
-//        self.assetsFilter = [ALAssetsFilter allPhotos];
+        //        self.assetsFilter = [ALAssetsFilter allPhotos];
         [self setAssetsFilter:[ALAssetsFilter allPhotos] type:1];
         
         [self setupAssets:endBlock];
@@ -288,7 +288,7 @@
     else
     {
         self.maximumNumberOfSelection = self.maximumNumberOfSelectionVideo;
-//        self.assetsFilter = [ALAssetsFilter allVideos];
+        //        self.assetsFilter = [ALAssetsFilter allVideos];
         [self setAssetsFilter:[ALAssetsFilter allVideos] type:2];
         
         [self setupAssets:endBlock];
@@ -356,7 +356,7 @@
         strongSelf.btnDone.enabled = NO;
         strongSelf.btnCamera.enabled = NO;
         [strongSelf setTitle:NSLocalizedStringFromTable(@"Not Allowed", @"UzysAssetsPickerController",nil)];
-//        [self.btnTitle setTitle:NSLocalizedStringFromTable(@"Not Allowed", @"UzysAssetsPickerController",nil) forState:UIControlStateNormal];
+        //        [self.btnTitle setTitle:NSLocalizedStringFromTable(@"Not Allowed", @"UzysAssetsPickerController",nil) forState:UIControlStateNormal];
         [strongSelf.btnTitle setImage:nil forState:UIControlStateNormal];
         
     };
@@ -381,7 +381,7 @@
     }
     [self.assetsGroup setAssetsFilter:self.assetsFilter];
     __weak typeof(self) weakSelf = self;
-
+    
     ALAssetsGroupEnumerationResultsBlock resultsBlock = ^(ALAsset *asset, NSUInteger index, BOOL *stop) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (asset)
@@ -404,7 +404,7 @@
                     successBlock();
                 
             });
-
+            
         }
     };
     [self.assetsGroup enumerateAssetsWithOptions:NSEnumerationReverse usingBlock:resultsBlock];
@@ -530,7 +530,7 @@
         title.text = NSLocalizedStringFromTable(@"No Videos", @"UzysAssetsPickerController",nil);
         UILabel *msg = (UILabel *)[weakSelf.noAssetView viewWithTag:kTagNoAssetViewMsgLabel];
         msg.text = NSLocalizedStringFromTable(@"You can sync videos onto your iPhone using iTunes.",@"UzysAssetsPickerController", nil);
-
+        
     };
     
     if(self.assets.count ==0)
@@ -558,7 +558,7 @@
                 title.text = NSLocalizedStringFromTable(@"No Videos", @"UzysAssetsPickerController",nil);
                 UILabel *msg = (UILabel *)[self.noAssetView viewWithTag:kTagNoAssetViewMsgLabel];
                 msg.text = NSLocalizedStringFromTable(@"You can sync media onto your iPhone using iTunes.",@"UzysAssetsPickerController", nil);
-
+                
             }
             else if(self.maximumNumberOfSelectionPhoto == 0)
             {
@@ -613,16 +613,11 @@
 
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    ALAsset *selectedAsset = [self.assets objectAtIndex:indexPath.item];
-    [self.orderedSelectedItem addObject:selectedAsset];
     [self setAssetsCountWithSelectedIndexPaths:collectionView.indexPathsForSelectedItems];
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath
 {
-    ALAsset *deselectedAsset = [self.assets objectAtIndex:indexPath.item];
-
-    [self.orderedSelectedItem removeObject:deselectedAsset];
     [self setAssetsCountWithSelectedIndexPaths:collectionView.indexPathsForSelectedItems];
 }
 
@@ -631,13 +626,13 @@
 
 - (void)finishPickingAssets
 {
-    NSMutableArray *assets = [[NSMutableArray alloc] initWithArray:self.orderedSelectedItem];
-//
-//    for (NSIndexPath *index in self.orderedSelectedItem)
-//    {
-//        [assets addObject:[self.assets objectAtIndex:index.item]];
-//    }
-//    
+    NSMutableArray *assets = [[NSMutableArray alloc] init];
+    
+    for (NSIndexPath *indexPath in self.collectionView.indexPathsForSelectedItems)
+    {
+        [assets addObject:[self.assets objectAtIndex:indexPath.item]];
+    }
+    
     if([assets count]>0)
     {
         UzysAssetsPickerController *picker = (UzysAssetsPickerController *)self;
@@ -679,9 +674,60 @@
             index = idx;
             *stop = YES;
         }
-
+        
     }];
     return index;
+}
+
+- (NSString *)getUTCFormattedDate:(NSDate *)localDate {
+    static NSDateFormatter *dateFormatter = nil;
+    if (dateFormatter == nil) {
+        dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"yyyy:MM:dd HH:mm:ss"];
+    }
+    NSString *dateString = [dateFormatter stringFromDate:localDate];
+    return dateString;
+}
+
+// Mostly from here: http://stackoverflow.com/questions/3884060/need-help-in-saving-geotag-info-with-photo-on-ios4-1
+- (NSMutableDictionary*)addGPSLocation:(NSMutableDictionary *)metaData {
+    
+    if (self.location != nil) {
+        
+        CLLocationDegrees exifLatitude  = location.coordinate.latitude;
+        CLLocationDegrees exifLongitude = location.coordinate.longitude;
+        
+        NSString *latRef;
+        NSString *lngRef;
+        if (exifLatitude < 0.0) {
+            exifLatitude = exifLatitude * -1.0f;
+            latRef = @"S";
+        } else {
+            latRef = @"N";
+        }
+        
+        if (exifLongitude < 0.0) {
+            exifLongitude = exifLongitude * -1.0f;
+            lngRef = @"W";
+        } else {
+            lngRef = @"E";
+        }
+        
+        NSMutableDictionary *locDict = [[NSMutableDictionary alloc] init];
+        if ([metaData objectForKey:(NSString*)kCGImagePropertyGPSDictionary]) {
+            [locDict addEntriesFromDictionary:[metaData objectForKey:(NSString*)kCGImagePropertyGPSDictionary]];
+        }
+        [locDict setObject:[self getUTCFormattedDate:location.timestamp] forKey:(NSString*)kCGImagePropertyGPSTimeStamp];
+        [locDict setObject:latRef forKey:(NSString*)kCGImagePropertyGPSLatitudeRef];
+        [locDict setObject:[NSNumber numberWithFloat:exifLatitude] forKey:(NSString*)kCGImagePropertyGPSLatitude];
+        [locDict setObject:lngRef forKey:(NSString*)kCGImagePropertyGPSLongitudeRef];
+        [locDict setObject:[NSNumber numberWithFloat:exifLongitude] forKey:(NSString*)kCGImagePropertyGPSLongitude];
+        [locDict setObject:[NSNumber numberWithFloat:location.horizontalAccuracy] forKey:(NSString*)kCGImagePropertyGPSDOP];
+        [locDict setObject:[NSNumber numberWithFloat:location.altitude] forKey:(NSString*)kCGImagePropertyGPSAltitude];
+        
+        [metaData setObject:locDict forKey:(NSString*)kCGImagePropertyGPSDictionary];
+    }
+    return metaData;
 }
 
 #pragma mark - Notification
@@ -760,7 +806,7 @@
                 {
                     NSMutableArray *selectedItems = [NSMutableArray array];
                     NSArray *selectedPath = strongSelf.collectionView.indexPathsForSelectedItems;
-                  
+                    
                     for (NSIndexPath *idxPath in selectedPath)
                     {
                         [selectedItems addObject:[strongSelf.assets objectAtIndex:idxPath.row]];
@@ -769,7 +815,6 @@
                     [strongSelf setupAssets:^{
                         for (ALAsset *item in selectedItems)
                         {
-                            BOOL isExist = false;
                             for(ALAsset *asset in strongSelf.assets)
                             {
                                 if([[[asset valueForProperty:ALAssetPropertyAssetURL] absoluteString] isEqualToString:[[item valueForProperty:ALAssetPropertyAssetURL] absoluteString]])
@@ -777,27 +822,21 @@
                                     NSUInteger idx = [strongSelf.assets indexOfObject:asset];
                                     NSIndexPath *newPath = [NSIndexPath indexPathForRow:idx inSection:0];
                                     [strongSelf.collectionView selectItemAtIndexPath:newPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
-                                    isExist = true;
                                 }
                             }
-                            if(isExist ==false)
-                            {
-                                [strongSelf.orderedSelectedItem removeObject:item];
-                            }
                         }
-                    
                         [strongSelf setAssetsCountWithSelectedIndexPaths:strongSelf.collectionView.indexPathsForSelectedItems];
                         if(strongSelf.assets.count > beforeAssets)
                         {
                             [strongSelf.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
                         }
-
+                        
                     }];
                     [strongSelf setupGroup:^{
                         [strongSelf.groupPicker reloadData];
                     } withSetupAsset:NO];
                     
-
+                    
                 }
                 else
                 {
@@ -835,11 +874,11 @@
         }
     } completion:^(BOOL finished) {
     }];
-
+    
 }
 #pragma mark - Control Action
 - (IBAction)btnAction:(id)sender {
-
+    
     UIButton *btn = (UIButton *)sender;
     
     switch (btn.tag) {
@@ -928,7 +967,7 @@
                 
                 [self.assets insertObject:asset atIndex:0];
                 [self reloadData];
-
+                
                 for (ALAsset *item in selectedItems)
                 {
                     for(ALAsset *asset in self.assets)
@@ -947,7 +986,6 @@
                 {
                     NSIndexPath *newPath = [NSIndexPath indexPathForRow:0 inSection:0];
                     [self.collectionView selectItemAtIndexPath:newPath animated:NO scrollPosition:UICollectionViewScrollPositionNone];
-                    [self.orderedSelectedItem addObject:asset];
                 }
                 [self setAssetsCountWithSelectedIndexPaths:self.collectionView.indexPathsForSelectedItems];
             }
@@ -961,7 +999,7 @@
         });
         
     } failureBlock:^(NSError *err){
-
+        
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [[NSNotificationCenter defaultCenter] addObserver:strongSelf selector:@selector(assetsLibraryUpdated:) name:ALAssetsLibraryChangedNotification object:nil];
@@ -984,7 +1022,11 @@
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 UIImage *image = info[UIImagePickerControllerOriginalImage];
                 [[NSNotificationCenter defaultCenter] removeObserver:strongSelf name:ALAssetsLibraryChangedNotification object:nil];
-                [strongSelf.assetsLibrary writeImageToSavedPhotosAlbum:image.CGImage metadata:info[UIImagePickerControllerMediaMetadata] completionBlock:^(NSURL *assetURL, NSError *error) {
+                
+                NSMutableDictionary *metaData = [NSMutableDictionary dictionaryWithDictionary:info[UIImagePickerControllerMediaMetadata]];
+                [self addGPSLocation:metaData];
+                
+                [strongSelf.assetsLibrary writeImageToSavedPhotosAlbum:image.CGImage metadata:metaData completionBlock:^(NSURL *assetURL, NSError *error) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [self saveAssetsAction:assetURL error:error isPhoto:YES];
                     });
@@ -998,7 +1040,11 @@
         {
             UIImage *image = info[UIImagePickerControllerOriginalImage];
             [[NSNotificationCenter defaultCenter] removeObserver:self name:ALAssetsLibraryChangedNotification object:nil];
-            [self.assetsLibrary writeImageToSavedPhotosAlbum:image.CGImage metadata:info[UIImagePickerControllerMediaMetadata] completionBlock:^(NSURL *assetURL, NSError *error) {
+            
+            NSMutableDictionary *metaData = [NSMutableDictionary dictionaryWithDictionary:info[UIImagePickerControllerMediaMetadata]];
+            [self addGPSLocation:metaData];
+            DLog(@"metadata: %@", metaData.description);
+            [self.assetsLibrary writeImageToSavedPhotosAlbum:image.CGImage metadata:metaData completionBlock:^(NSURL *assetURL, NSError *error) {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [strongSelf saveAssetsAction:assetURL error:error isPhoto:YES];
@@ -1014,7 +1060,7 @@
             self.segmentedControl.selectedSegmentIndex = 1;
             [self changeAssetType:NO endBlock:^{
                 __strong typeof(weakSelf) strongSelf = weakSelf;
-
+                
                 [[NSNotificationCenter defaultCenter] removeObserver:strongSelf name:ALAssetsLibraryChangedNotification object:nil];
                 [strongSelf.assetsLibrary writeVideoAtPathToSavedPhotosAlbum:info[UIImagePickerControllerMediaURL] completionBlock:^(NSURL *assetURL, NSError *error) {
                     DLog(@"assetURL %@",assetURL);
@@ -1039,7 +1085,7 @@
     }
     
     [picker dismissViewControllerAnimated:YES completion:^{}];
-
+    
     
 }
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -698,7 +698,7 @@
 }
 
 // Mostly from here: http://stackoverflow.com/questions/3884060/need-help-in-saving-geotag-info-with-photo-on-ios4-1
-- (NSMutableDictionary*)addGPSLocation:(NSMutableDictionary *)metaData {
+- (void)addGPSLocation:(NSMutableDictionary *)metaData {
     
     if (self.location != nil) {
         
@@ -735,7 +735,6 @@
         
         [metaData setObject:locDict forKey:(NSString*)kCGImagePropertyGPSDictionary];
     }
-    return metaData;
 }
 
 #pragma mark - Notification


### PR DESCRIPTION
Photos taken by the iPhone camera app contain locative metadata (GPS dictionary) but photos taken by the UIImagePickerController do not. This patch adds an instance variable "location" that can be set with a CLLocation object at the same time as when the UzysAssetsPickerController delegate is set, and when the didFinishPickingMediaWithInfo delegate method processes the image it will construct and add the GPS dictionary to the metadata written using writeImageToSavedPhotosAlbum:metadata. 