### PR TITLE
Add some configs

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
@@ -17,6 +17,8 @@
 @property (nonatomic, strong) NSString *cameraImageName;
 @property (nonatomic, strong) NSString *closeImageName;
 @property (nonatomic, strong) UIColor *finishSelectionButtonColor;
+//
+@property (nonatomic, assign) NSInteger assetsCountInALine;
 
 + (instancetype)sharedConfig;
 @end

--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) UIColor *finishSelectionButtonColor;
 //
 @property (nonatomic, assign) NSInteger assetsCountInALine;
+@property (nonatomic, assign) CGFloat cellSpacing;
 
 + (instancetype)sharedConfig;
 @end

--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
@@ -17,6 +17,7 @@
     dispatch_once(&onceToken, ^{
         shared = [[self alloc] init];
         shared.assetsCountInALine = 4;
+        shared.cellSpacing = 1.0f;
     });
     return shared;
 }

--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
@@ -16,6 +16,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         shared = [[self alloc] init];
+        shared.assetsCountInALine = 4;
     });
     return shared;
 }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -238,6 +238,7 @@
     self.collectionView.backgroundColor = [UIColor whiteColor];
     self.collectionView.bounces = YES;
     self.collectionView.alwaysBounceVertical = YES;
+    self.collectionView.scrollsToTop = YES;
 
     [self.view insertSubview:self.collectionView atIndex:0];
 }

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -222,11 +222,11 @@
     
     UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
     
-    CGFloat itemWidth = ([UIScreen mainScreen].bounds.size.width - 4.0f * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
+    CGFloat itemWidth = ([UIScreen mainScreen].bounds.size.width - appearanceConfig.cellSpacing * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
     layout.itemSize = CGSizeMake(itemWidth, itemWidth);
     layout.sectionInset                 = UIEdgeInsetsMake(1.0, 0, 0, 0);
     layout.minimumInteritemSpacing      = 1.0;
-    layout.minimumLineSpacing           = 1.0;
+    layout.minimumLineSpacing           = appearanceConfig.cellSpacing;
 
     self.collectionView = [[UICollectionView alloc] initWithFrame:CGRectMake(0, 64, [UIScreen mainScreen].bounds.size.width, [UIScreen mainScreen].bounds.size.height - 64 -48) collectionViewLayout:layout];
     self.collectionView.allowsMultipleSelection = YES;
@@ -259,6 +259,7 @@
     appearanceConfig.assetsGroupSelectedImageName = config.assetsGroupSelectedImageName;
     appearanceConfig.closeImageName = config.closeImageName;
     appearanceConfig.assetsCountInALine = config.assetsCountInALine;
+    appearanceConfig.cellSpacing = config.cellSpacing;
 }
 
 - (void)changeGroup:(NSInteger)item

--- a/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsPickerController.m
@@ -220,18 +220,10 @@
     
     UICollectionViewFlowLayout *layout  = [[UICollectionViewFlowLayout alloc] init];
     
-    if(IS_IPHONE_6_IOS8)
-    {
-        layout.itemSize = kThumbnailSize_IPHONE6;
-    }
-    else if(IS_IPHONE_6P_IOS8)
-    {
-        layout.itemSize = kThumbnailSize_IPHONE6P;
-    }
-    else
-    {
-        layout.itemSize                     = kThumbnailSize;
-    }
+    UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
+    
+    CGFloat itemWidth = ([UIScreen mainScreen].bounds.size.width - 4.0f * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
+    layout.itemSize = CGSizeMake(itemWidth, itemWidth);
     layout.sectionInset                 = UIEdgeInsetsMake(1.0, 0, 0, 0);
     layout.minimumInteritemSpacing      = 1.0;
     layout.minimumLineSpacing           = 1.0;
@@ -265,6 +257,7 @@
     appearanceConfig.finishSelectionButtonColor = config.finishSelectionButtonColor;
     appearanceConfig.assetsGroupSelectedImageName = config.assetsGroupSelectedImageName;
     appearanceConfig.closeImageName = config.closeImageName;
+    appearanceConfig.assetsCountInALine = config.assetsCountInALine;
 }
 
 - (void)changeGroup:(NSInteger)item

--- a/UzysAssetsPickerController/Library/UzysAssetsViewCell.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsViewCell.m
@@ -40,18 +40,7 @@ static CGFloat thumnailLength;
     uncheckedIcon   = [UIImage Uzys_imageNamed:appearanceConfig.assetDeselectedImageName];
     selectedColor   = [UIColor colorWithWhite:1 alpha:0.3];
     
-    if(IS_IPHONE_6_IOS8)
-    {
-        thumnailLength = kThumbnailLength_IPHONE6;
-    }
-    else if(IS_IPHONE_6P_IOS8)
-    {
-        thumnailLength = kThumbnailLength_IPHONE6P;
-    }
-    else
-    {
-        thumnailLength = kThumbnailLength;
-    }
+    thumnailLength = ([UIScreen mainScreen].bounds.size.width - 4.0f * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
 }
 
 
@@ -110,7 +99,7 @@ static CGFloat thumnailLength;
 - (void)drawRect:(CGRect)rect
 {
     // Image
-    [self.image drawInRect:CGRectMake(0, 0, thumnailLength, thumnailLength)];
+    [self.image drawInRect:CGRectMake(-.5f, -1.0f, thumnailLength+1.5f, thumnailLength+1.0f)];
     
     // Video title
     if ([self.type isEqual:ALAssetTypeVideo])

--- a/UzysAssetsPickerController/Library/UzysAssetsViewCell.m
+++ b/UzysAssetsPickerController/Library/UzysAssetsViewCell.m
@@ -40,7 +40,7 @@ static CGFloat thumnailLength;
     uncheckedIcon   = [UIImage Uzys_imageNamed:appearanceConfig.assetDeselectedImageName];
     selectedColor   = [UIColor colorWithWhite:1 alpha:0.3];
     
-    thumnailLength = ([UIScreen mainScreen].bounds.size.width - 4.0f * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
+    thumnailLength = ([UIScreen mainScreen].bounds.size.width - appearanceConfig.cellSpacing * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
 }
 
 

--- a/UzysAssetsPickerController/Library/UzysGroupPickerView.m
+++ b/UzysAssetsPickerController/Library/UzysGroupPickerView.m
@@ -48,6 +48,7 @@
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
+    self.tableView.scrollsToTop = NO;
     
     self.tableView.rowHeight = kGroupPickerViewCellLength;
     self.tableView.backgroundColor = [UIColor whiteColor];

--- a/UzysAssetsPickerController/uzysViewController.m
+++ b/UzysAssetsPickerController/uzysViewController.m
@@ -85,6 +85,8 @@
     UzysAppearanceConfig *appearanceConfig = [[UzysAppearanceConfig alloc] init];
     appearanceConfig.finishSelectionButtonColor = [UIColor blueColor];
     appearanceConfig.assetsGroupSelectedImageName = @"checker.png";
+    appearanceConfig.cellSpacing = 4.0f;
+    appearanceConfig.assetsCountInALine = 3;
     [UzysAssetsPickerController setUpAppearanceConfig:appearanceConfig];
 #endif
 


### PR DESCRIPTION
좀더 커스터마이즈 하기 쉽도록 UzysAppearanceConfig에 몇가지 속성을 추가했습니다.

### Cell 간격
* `@property (nonatomic, assign) CGFloat cellSpacing;`
 * Cell 사이의 간격입니다.
 * 기본값: **1.0f**

### 한 줄당 사진 개수
* `@property (nonatomic, assign) CGFloat cellSpacing;`
 * Collection view 가로 한 줄의 사진 Cell 개수입니다.
 * 기본값: **4**

### Scrolls to top
* 상단 Status bar를 탭하면, Collection view가 최상단으로 올라가는 scrollsToTop이 작동하지 않는 버그를 해결했습니다.

위의 기능들을 시연할 수 있는 코드를 `uzysViewController`에 추가했습니다.

---

I added some property to UzysAppearanceConfig to make developers should customize this assets picker more easily.

### Cell spacing
* `@property (nonatomic, assign) CGFloat cellSpacing;`
 * The spacing between cells.
 * Default value is **1.0f**

### Assets count in a line.
* `@property (nonatomic, assign) NSInteger assetsCountInALine;`
 * The number of cell-count in a horizontal line.
 * Default value is *4*

### Scrolls to top
* I fix the bug, the collection view is impossible to scroll to top when user tapped the status bar.

I also wrote some code into `uzysViewController` to demonstrate.