### PR TITLE
Fixed issue with incorrect singleton creation leading to divide-by-zero-related crash.

### DIFF
--- a/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
+++ b/UzysAssetsPickerController/Library/UzysAppearanceConfig.m
@@ -16,10 +16,20 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         shared = [[self alloc] init];
-        shared.assetsCountInALine = 4;
-        shared.cellSpacing = 1.0f;
     });
     return shared;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+
+    if (self) {
+        self.assetsCountInALine = 4;
+        self.cellSpacing = 1.0f;
+    }
+
+    return self;
 }
 
 - (NSString *)assetSelectedImageName


### PR DESCRIPTION
The way the `UzysAppearanceConfig` singleton was created lead to the `assetsCountInALine` and `cellSpacing` properties to not be saved on it, resulting in a crash originating on `UzysAssetsPickerController.h` line 228, where the `assetsCountInALine` param was 0 and was passed into the `itemSize` property on the flow layout for the collection view. (From: https://github.com/uzysjung/UzysAssetsPickerController/pull/48)

```
UzysAppearanceConfig *appearanceConfig = [UzysAppearanceConfig sharedConfig];
    
CGFloat itemWidth = ([UIScreen mainScreen].bounds.size.width - appearanceConfig.cellSpacing * ((CGFloat)appearanceConfig.assetsCountInALine - 1.0f)) / (CGFloat)appearanceConfig.assetsCountInALine;
```
This pull request uses a more conventional approach to creating the singleton and setting the initial properties on it, preventing this issue.